### PR TITLE
Move scripts to end of body

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,13 +27,6 @@
 		<link href="https://fonts.googleapis.com/css?family=Roboto|Roboto+Condensed|Alegreya:700" rel="stylesheet" type="text/css" />
 		<link rel="stylesheet" href="styles/leaflet.css">
 		<link rel="stylesheet" href="https://cdn.rawgit.com/ardhi/Leaflet.MousePosition/master/src/L.Control.MousePosition.css">
-		<!-- Vendor scripts -->
-		<script src="scripts/leaflet.js" type="text/javascript"></script>
-		<script src="scripts/groupedlayercontrol.js" type="text/javascript"></script>
-		<script src="scripts/easy-button.js" type="text/javascript"></script>
-		<script src="scripts/icons.js" type="text/javascript"></script>
-		<script src="https://cdn.rawgit.com/ardhi/Leaflet.MousePosition/master/src/L.Control.MousePosition.js" type="text/javascript"></script>
-		<script src="scripts/hash.js" type="text/javascript"></script>
 
 		<link rel="apple-touch-icon" sizes="180x180" href="apple-touch-icon.png">
 		<link rel="icon" type="image/png" sizes="32x32" href="favicon-32x32.png">
@@ -116,11 +109,7 @@
 		</div>
 
 		<div id="map" class="wrapper  clearfix  map">
-			<main>	
-					<script type="text/javascript" src="scripts/mapData.js">
-						//If you're reading this, you're beautiful.
-					</script>
-			</main>
+			<main></main>
 		</div>
 
 		<div class="button-wrapper  clearfix">
@@ -135,6 +124,16 @@
 			</div>
 		</div>
 
+		<!-- Vendor scripts -->
+		<script src="scripts/leaflet.js" type="text/javascript"></script>
+		<script src="scripts/groupedlayercontrol.js" type="text/javascript"></script>
+		<script src="scripts/easy-button.js" type="text/javascript"></script>
+		<script src="scripts/icons.js" type="text/javascript"></script>
+		<script src="https://cdn.rawgit.com/ardhi/Leaflet.MousePosition/master/src/L.Control.MousePosition.js" type="text/javascript"></script>
+		<script src="scripts/hash.js" type="text/javascript"></script>
+
+		<!-- App -->
+		<script type="text/javascript" src="scripts/mapData.js"></script>
 		<script src="scripts/pageEvents.js" type="text/javascript"></script>
 	</body>
 </html>


### PR DESCRIPTION
It's recommended that <script> tags should be at the end of the body in most cases.

1. The page can start fecthing images and visual elements before your scripts
2. If any script tag depends on DOM existing, the scripts should be loaded last in most cases

It's a general hygiene thing but the code works without it.